### PR TITLE
Temp fix until we update tree-sitter.  

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,8 @@
+try { // temp fix until we update tree-sitter.
+    // @ts-ignore
+    delete WebAssembly.instantiateStreaming;
+} catch {}
+
 import * as vscode from 'vscode';
 import { actionList, registerAction } from './actions/action';
 import { EditorData, EditorDataManager } from './editor/editordata';


### PR DESCRIPTION
(old tree-sitter not compat with new node.js).

Code is based on discussion in the tree-sitter issues.  Newer tree-sitter versions have fixed this, but until then, this resolves the problem of being unable to load tree-sitter-mode because Parser.Init() hangs.